### PR TITLE
AWS CodeStar source connection support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
-* Addins conditional support for CodeStar source code connections
+* Adding conditional support for CodeStar source code connections
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+* Addins conditional support for CodeStar source code connections
 
 ## 3.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+
 * Adding conditional support for CodeStar source code connections
+* Upgrading to Terraform 12
 
 ## 3.0.1
 

--- a/README.md
+++ b/README.md
@@ -74,14 +74,14 @@ Note: If an empty list is supplied via whitelisted_ips or whitelisted_ips is omm
 
 The project default assumes that the website code is hosted in AWS CodeCommit. GitHub and Bitbucket source repositories are supported via integration with AWS CodeStar using an optional parameter to the Terraform module code named `code_star_connection_arn`. The connection ARN should be created in the AWS console as a manual process using one of the following guides from AWS documentation:
 
-* ![GitHub connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-github.html)
-* ![Bitbucket connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-bitbucket.html)
+* [GitHub connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-github.html)
+* [Bitbucket connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-bitbucket.html)
 
 Copy the ARN as specified in the documentation. It should be of the format: `arn:aws:codestar-connections:us-west-2:account_id:connection/aEXAMPLE-8aad-4d5d-8878-dfcab0bc441f`.
 
 Use this value as the input for the `code_star_connection_arn` variable in the Terraform module code.
 
-Also, when using GitHub or Bitbucket, the value for the `code_commit_repo_name` should be the "full repository id" as specified in the ![AWS CodePipeline documentation for CodeStar](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html). This value should take the form `some-user/my-repo`, or `ordinaryexperts/terraform-aws-static-website-with-cicd` for this GitHub project.
+Also, when using GitHub or Bitbucket, the value for the `code_commit_repo_name` should be the "full repository id" as specified in the [AWS CodePipeline documentation for CodeStar](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html). This value should take the form `some-user/my-repo`, or `ordinaryexperts/terraform-aws-static-website-with-cicd` for this GitHub project.
 
 ## Known Issues / Limitations
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # terraform-aws-static-website-with-cicd
 
-A static s3-backed website with CloudFront, SSL, and automatic deployments on commits to a CodeCommit git repo.
+A static s3-backed website with CloudFront, SSL, and automatic deployments on commits to a git repo (CodeCommit natively supported, Bitbucket Cloud, GitHub, GitHub Enterprise Cloud, GitHub Enterprise Server supported via CodeStar connections).
 The user can supply a list of IP addresses to whitelist to access the s3-backed website via the whitelisted_ips list.
 The whitelist will be implemented via a WAF and WAFRule.
 If whitelisted_ips contains an empty list then the WAF and WAFRule will not be allocated.
@@ -49,8 +49,8 @@ aws-vault comes in very handy during stack deployment (and otherwise):
 
       code_build_docker_image_identifier = "aws/codebuild/ruby:2.5.3"
       cert_arn = "YOUR_CERTIFICATE_ARN"
-      code_commit_repo_branch = "YOUR_CODE_COMMIT_REPO_BRANCH"
-      code_commit_repo_name = "YOUR_CODE_COMMIT_REPO_NAME"
+      repo_branch = "YOUR_REPO_BRANCH"
+      repo_name = "YOUR_REPO_NAME"
       domain = "static-site-testing.mycompanyname.com"
       env = "test1"
       notification_email = "hello@myemail.com"
@@ -64,7 +64,7 @@ aws-vault comes in very handy during stack deployment (and otherwise):
 1. The bucket region value is "us-east-1" for US East (N. Virginia), for example.
 1. The region under provider is for the CloudFormation stack.
 1. The cert_arn value is the ARN from AWS Certificate Manager.
-1. The values for code_commit_repo_branch and code_commit_repo_name are for the code you want to use for your static website.
+1. The values for repo_branch and repo_name are for the code you want to use for your static website.
 1. The domain should coincide with the domain of the certificate that cert_arn is refering to.
 1. The list of IPs to whitelist are to be specified in whitelisted_ips.
 
@@ -81,7 +81,7 @@ Copy the ARN as specified in the documentation. It should be of the format: `arn
 
 Use this value as the input for the `code_star_connection_arn` variable in the Terraform module code.
 
-Also, when using GitHub or Bitbucket, the value for the `code_commit_repo_name` should be the "full repository id" as specified in the [AWS CodePipeline documentation for CodeStar](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html). This value should take the form `some-user/my-repo`, or `ordinaryexperts/terraform-aws-static-website-with-cicd` for this GitHub project.
+Also, when using GitHub or Bitbucket, the value for the `repo_name` should be the "full repository id" as specified in the [AWS CodePipeline documentation for CodeStar](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html). This value should take the form `some-user/my-repo`, or `ordinaryexperts/terraform-aws-static-website-with-cicd` for this GitHub project.
 
 ## Known Issues / Limitations
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ If whitelisted_ips contains an empty list then the WAF and WAFRule will not be a
 This module makes several assumptions:
 
 1. US East (N. Virginia) is the AWS region (see Limitations below)
-1. The code for the website is stored in a CodeCommit repository
 1. The SSL certificate for the website has been provisioned with the AWS Certificate Manager
 1. The build command for the website defaults to a `build` script in the root of the repo
 1. The build command places the files to be published into a `public` directory
@@ -70,7 +69,18 @@ aws-vault comes in very handy during stack deployment (and otherwise):
 1. The list of IPs to whitelist are to be specified in whitelisted_ips.
 
 Note: If an empty list is supplied via whitelisted_ips or whitelisted_ips is ommited altogether than a WAF will NOT be created and the static website will be open to the world.
- 
+
+### AWS CodeStar for code repositories in Bitbucket and Github
+
+The project default assumes that the website code is hosted in AWS CodeCommit. GitHub and Bitbucket source repositories are supported via integration with AWS CodeStar using an optional parameter to the Terraform module code named `code_star_connection_arn`. The connection ARN should be created in the AWS console as a manual process using one of the following guides from AWS documentation:
+
+* ![GitHub connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-github.html)
+* ![Bitbucket connections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-bitbucket.html)
+
+Copy the ARN as specified in the documentation. It should be of the format: `arn:aws:codestar-connections:us-west-2:account_id:connection/aEXAMPLE-8aad-4d5d-8878-dfcab0bc441f`.
+
+Use this value as the input for the `code_star_connection_arn` variable in the Terraform module code.
+
 ## Known Issues / Limitations
 
 *Must be launched in US East (N. Virginia)*

--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Copy the ARN as specified in the documentation. It should be of the format: `arn
 
 Use this value as the input for the `code_star_connection_arn` variable in the Terraform module code.
 
+Also, when using GitHub or Bitbucket, the value for the `code_commit_repo_name` should be the "full repository id" as specified in the ![AWS CodePipeline documentation for CodeStar](https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html). This value should take the form `some-user/my-repo`, or `ordinaryexperts/terraform-aws-static-website-with-cicd` for this GitHub project.
+
 ## Known Issues / Limitations
 
 *Must be launched in US East (N. Virginia)*

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ aws-vault comes in very handy during stack deployment (and otherwise):
 1. The domain should coincide with the domain of the certificate that cert_arn is refering to.
 1. The list of IPs to whitelist are to be specified in whitelisted_ips.
 
-Note: If an empty list is supplied via whitelisted_ips or whitelisted_ips is ommited altogether than a WAF will NOT be created and the static website will be open to the world.
+Note: If an empty list is supplied via whitelisted_ips or whitelisted_ips is omitted altogether than a WAF will NOT be created and the static website will be open to the world.
 
 ### AWS CodeStar for code repositories in Bitbucket and Github
 

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,7 @@ resource "aws_cloudformation_stack" "website_cicd" {
   parameters = {
     BuildCommand = var.build_command
     CodeBuildDockerImageIdentifier = var.code_build_docker_image_identifier
+    CodeStarSourceConnectionArn = var.code_star_connection_arn
     CloudFrontDistributionId = aws_cloudformation_stack.website_bucket_and_cf.outputs["CloudFrontDistributionId"]
     NotificationEmail = var.notification_email
     PipelineBucket = aws_cloudformation_stack.pipeline_bucket.outputs["PipelineBucket"]

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 resource "aws_waf_ipset" "whitelisted_ips" {
-  count = "${length(var.whitelisted_ips) > 0 ? 1 : 0}"
+  count = length(var.whitelisted_ips) > 0 ? 1 : 0
   name = "WhitelistedIps"
 
   dynamic "ip_set_descriptors" {
@@ -14,8 +14,8 @@ resource "aws_waf_ipset" "whitelisted_ips" {
 }
 
 resource "aws_waf_rule" "whitelisted_ips_rule" {
-  count = "${length(var.whitelisted_ips) > 0 ? 1 : 0}"
-  depends_on  = ["aws_waf_ipset.whitelisted_ips"]
+  count = length(var.whitelisted_ips) > 0 ? 1 : 0
+  depends_on  = [aws_waf_ipset.whitelisted_ips]
   name        = "${var.env}WhitelistedIPsRule"
   metric_name = "${var.env}WhitelistedIPsRule"
 
@@ -27,8 +27,8 @@ resource "aws_waf_rule" "whitelisted_ips_rule" {
 }
 
 resource "aws_waf_web_acl" "whitelisted_ips_acl" {
-  count = "${length(var.whitelisted_ips) > 0 ? 1 : 0}"
-  depends_on  = ["aws_waf_rule.whitelisted_ips_rule"]
+  count = length(var.whitelisted_ips) > 0 ? 1 : 0
+  depends_on  = [aws_waf_rule.whitelisted_ips_rule]
   name        = "${var.env}WhitelistedIPsACL"
   metric_name = "${var.env}WhitelistedIPsACL"
 
@@ -50,16 +50,16 @@ resource "aws_waf_web_acl" "whitelisted_ips_acl" {
 resource "aws_cloudformation_stack" "website_bucket_and_cf" {
   name = "${var.env}-website-bucket-and-cf-stack"
   capabilities = ["CAPABILITY_IAM"]
-  depends_on = ["aws_waf_web_acl.whitelisted_ips_acl"]
+  depends_on = [aws_waf_web_acl.whitelisted_ips_acl]
   on_failure = "DELETE"
   parameters = {
     CertificateArn = var.cert_arn
     CustomErrorResponsePagePath = var.custom_error_response_page_path
     Debug = var.debug
     Domain = var.domain
-    WebACLId = "${length(var.whitelisted_ips) > 0 ? "${join("", aws_waf_web_acl.whitelisted_ips_acl.*.id)}" : "none"}"
+    WebACLId = length(var.whitelisted_ips) > 0 ? "${join("", aws_waf_web_acl.whitelisted_ips_acl.*.id)}" : "none"
   }
-  template_body = "${file("${path.module}/website_bucket_and_cf.yaml")}"
+  template_body = file("${path.module}/website_bucket_and_cf.yaml")
   # CloudFront distributions can take a long time to create...
   timeouts {
     create = "2h"
@@ -72,12 +72,12 @@ resource "aws_cloudformation_stack" "website_bucket_and_cf" {
 resource "aws_cloudformation_stack" "pipeline_bucket" {
   name = "${var.env}-website-pipeline-bucket-stack"
   on_failure = "DELETE"
-  template_body = "${file("${path.module}/pipeline_bucket.yaml")}"
+  template_body = file("${path.module}/pipeline_bucket.yaml")
 }
 
 resource "aws_cloudformation_stack" "website_cicd" {
   capabilities = ["CAPABILITY_IAM"]
-  depends_on = ["aws_cloudformation_stack.website_bucket_and_cf"]
+  depends_on = [aws_cloudformation_stack.website_bucket_and_cf]
   name = "${var.env}-website-cicd-stack"
   on_failure = "DELETE"
   parameters = {
@@ -91,5 +91,5 @@ resource "aws_cloudformation_stack" "website_cicd" {
     SourceRepoName = var.repo_name
     WebsiteBucket = aws_cloudformation_stack.website_bucket_and_cf.outputs["WebsiteBucket"]
   }
-  template_body = "${file("${path.module}/website_cicd.yaml")}"
+  template_body = file("${path.module}/website_cicd.yaml")
 }

--- a/main.tf
+++ b/main.tf
@@ -87,8 +87,8 @@ resource "aws_cloudformation_stack" "website_cicd" {
     CloudFrontDistributionId = aws_cloudformation_stack.website_bucket_and_cf.outputs["CloudFrontDistributionId"]
     NotificationEmail = var.notification_email
     PipelineBucket = aws_cloudformation_stack.pipeline_bucket.outputs["PipelineBucket"]
-    SourceCodeCommitRepoBranch = var.code_commit_repo_branch
-    SourceCodeCommitRepoName = var.code_commit_repo_name
+    SourceRepoBranch = var.repo_branch
+    SourceRepoName = var.repo_name
     WebsiteBucket = aws_cloudformation_stack.website_bucket_and_cf.outputs["WebsiteBucket"]
   }
   template_body = "${file("${path.module}/website_cicd.yaml")}"

--- a/variables.tf
+++ b/variables.tf
@@ -12,13 +12,13 @@ variable "code_build_docker_image_identifier" {
   default = "aws/codebuild/standard:3.0"
 }
 
-variable "code_commit_repo_branch" {
-  description = "The CodeCommit branch which will trigger deployments"
+variable "repo_branch" {
+  description = "The branch which will trigger deployments"
   default = "master"
 }
 
-variable "code_commit_repo_name" {
-  description = "The name of the CodeCommit repository hosting the site; if using AWS CodeStar for Github or Bitbucket repositories, this should bne the full repository id eg. someuser/myrepo"
+variable "repo_name" {
+  description = "The name of the repository hosting the site; if using AWS CodeStar for Github or Bitbucket repositories, this should be the full repository id eg. someuser/myrepo"
   default = "website"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -52,7 +52,7 @@ variable "notification_email" {
 
 variable "whitelisted_ips" {
   description = "The list of whitelisted IPs to use for the WAF IPSet"
-  type = "list"
+  type = list
   default = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -18,8 +18,13 @@ variable "code_commit_repo_branch" {
 }
 
 variable "code_commit_repo_name" {
-  description = "The name of the CodeCommit repository hosting the site"
+  description = "The name of the CodeCommit repository hosting the site; if using AWS CodeStar for Github or Bitbucket repositories, this should bne the full repository id eg. someuser/myrepo"
   default = "website"
+}
+
+variable "code_star_connection_arn" {
+  description = "The CodeStar connection ARN retrieved by manually creating the connection to a repository using the AWS console"
+  default = ""
 }
 
 variable "custom_error_response_page_path" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}

--- a/website_cicd.yaml
+++ b/website_cicd.yaml
@@ -22,10 +22,10 @@ Parameters:
   PipelineBucket:
     Type: String
 
-  SourceCodeCommitRepoName:
+  SourceRepoName:
     Type: String
 
-  SourceCodeCommitRepoBranch:
+  SourceRepoBranch:
     Type: String
 
   WebsiteBucket:
@@ -154,7 +154,7 @@ Resources:
                   - codecommit:UploadArchive
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:CancelUploadArchive
-                Resource: !Sub "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${SourceCodeCommitRepoName}"
+                Resource: !Sub "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${SourceRepoName}"
 
               -
                 Sid: AllowGetVersioningOnPipelineBucket
@@ -228,9 +228,9 @@ Resources:
                   Provider: CodeStarSourceConnection
                   Version: '1'
                 Configuration:
-                  BranchName: !Ref SourceCodeCommitRepoBranch
+                  BranchName: !Ref SourceRepoBranch
                   ConnectionArn: !Ref CodeStarSourceConnectionArn
-                  FullRepositoryId: !Ref SourceCodeCommitRepoName
+                  FullRepositoryId: !Ref SourceRepoName
                   OutputArtifactFormat: "CODEBUILD_CLONE_REF"
                 InputArtifacts: []
                 OutputArtifacts:
@@ -244,8 +244,8 @@ Resources:
                   Version: '1'
                   Provider: CodeCommit
                 Configuration:
-                  RepositoryName: !Ref SourceCodeCommitRepoName
-                  BranchName: !Ref SourceCodeCommitRepoBranch
+                  RepositoryName: !Ref SourceRepoName
+                  BranchName: !Ref SourceRepoBranch
                 InputArtifacts: []
                 OutputArtifacts:
                   - Name: SourceOutput

--- a/website_cicd.yaml
+++ b/website_cicd.yaml
@@ -2,10 +2,14 @@ AWSTemplateFormatVersion: '2010-09-09'
 
 Parameters:
 
-  BuildCommand:
+  CodeBuildDockerImageIdentifier:
     Type: String
 
-  CodeBuildDockerImageIdentifier:
+  CodeStarSourceConnectionArn:
+    Default: ''
+    Type: String
+
+  BuildCommand:
     Type: String
 
   CloudFrontDistributionId:
@@ -30,6 +34,8 @@ Parameters:
 Conditions:
 
   EnablePipelineNotifications: !Not [!Equals [ !Ref NotificationEmail, '' ]]
+
+  EnableCodeStarSource: !Not [!Equals [ !Ref CodeStarSourceConnectionArn, '' ]]
 
 Resources:
 
@@ -100,6 +106,16 @@ Resources:
                   # https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_aws-services-that-work-with-iam.html#networking_svcs
                   - "*"
                 Effect: Allow
+              - !If
+                - EnableCodeStarSource
+                -
+                  Sid: AllowCodeStarConnection
+                  Action:
+                    - codestar-connections:UseConnection
+                  Resource:
+                    - !Ref CodeStarSourceConnectionArn
+                  Effect: Allow
+                - !Ref AWS::NoValue
             Version: '2012-10-17'
 
   CodePipelineRole:
@@ -156,6 +172,16 @@ Resources:
                 Resource:
                   - !Sub "arn:aws:s3:::${PipelineBucket}/*"
                 Effect: Allow
+              - !If
+                - EnableCodeStarSource
+                -
+                  Sid: AllowCodeStarConnection
+                  Action:
+                    - codestar-connections:UseConnection
+                  Resource:
+                    - !Ref CodeStarSourceConnectionArn
+                  Effect: Allow
+                - !Ref AWS::NoValue
             Version: '2012-10-17'
 
   CodeBuildDeploySite:
@@ -192,20 +218,38 @@ Resources:
         -
           Name: Source
           Actions:
-            -
-              Name: Source
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: '1'
-                Provider: CodeCommit
-              Configuration:
-                RepositoryName: !Ref SourceCodeCommitRepoName
-                BranchName: !Ref SourceCodeCommitRepoBranch
-              InputArtifacts: []
-              OutputArtifacts:
-                - Name: SourceOutput
-              RunOrder: 1
+            - !If
+              - EnableCodeStarSource
+              -
+                Name: Source
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: '1'
+                Configuration:
+                  BranchName: !Ref SourceCodeCommitRepoBranch
+                  ConnectionArn: !Ref CodeStarSourceConnectionArn
+                  FullRepositoryId: !Ref SourceCodeCommitRepoName
+                  OutputArtifactFormat: "CODEBUILD_CLONE_REF"
+                InputArtifacts: []
+                OutputArtifacts:
+                  - Name: SourceOutput
+                RunOrder: 1
+              -
+                Name: Source
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Version: '1'
+                  Provider: CodeCommit
+                Configuration:
+                  RepositoryName: !Ref SourceCodeCommitRepoName
+                  BranchName: !Ref SourceCodeCommitRepoBranch
+                InputArtifacts: []
+                OutputArtifacts:
+                  - Name: SourceOutput
+                RunOrder: 1
         -
           Name: Deploy
           Actions:


### PR DESCRIPTION
Added the ability to use AWS CodeStar connections, namely Bitbucket and Github. This has only been lightly tested with Bitbucket, so it would be definitely nice to try a redeploy of the OE site to make sure backwards compatibility isn't broken.

Needs more testing, but the initial idea seems workable.