### PR TITLE
Upgrade CodeBuild image and Lambda runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+* Upgrade CodeBuild image and Lambda runtime
+
 ## 4.0.0
 
 * Adding conditional support for CodeStar source code connections

--- a/variables.tf
+++ b/variables.tf
@@ -9,7 +9,7 @@ variable "cert_arn" {
 
 variable "code_build_docker_image_identifier" {
   description = "Docker Image Identifier: https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html"
-  default = "aws/codebuild/standard:3.0"
+  default = "aws/codebuild/standard:4.0"
 }
 
 variable "repo_branch" {

--- a/website_bucket_and_cf.yaml
+++ b/website_bucket_and_cf.yaml
@@ -116,7 +116,7 @@ Resources:
             request.uri = newUri;
             return request;
           };
-      Runtime: nodejs10.x
+      Runtime: nodejs12.x
       Timeout: 5
       Handler: index.handler
       MemorySize: 128


### PR DESCRIPTION
Upgrading default codebuild image to 4.0, as 3.0 is no longer supported by AWS.

Upgrading Lambda NodeJS runtime to 12.x as 10.x is entering end of support phase.

In response to AWS notification to client.